### PR TITLE
refactor: preparing for different plugin types

### DIFF
--- a/plugins/input/python_analyzer.py
+++ b/plugins/input/python_analyzer.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import List, Optional, Tuple
 
 # Add the shared directory to the path so we can import base_analyzer
-sys.path.insert(0, str(Path(__file__).parent / "shared"))
+sys.path.insert(0, str(Path(__file__).parent / "../shared"))
 typing.cast(io.TextIOWrapper, sys.stdout).reconfigure(line_buffering=True)
 
 from base_analyzer import (

--- a/plugins/input/rust_analyzer.py
+++ b/plugins/input/rust_analyzer.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import List, Dict, Any, Optional, Set, Tuple, Union
 
 # Add the shared directory to the path so we can import base_analyzer
-sys.path.insert(0, str(Path(__file__).parent / "shared"))
+sys.path.insert(0, str(Path(__file__).parent / "../shared"))
 
 from base_analyzer import (
     BaseAnalyzer,

--- a/src/core/scanner.rs
+++ b/src/core/scanner.rs
@@ -2,7 +2,7 @@ use crate::core::matrix::ProjectMatrix;
 use crate::utils::config::Config;
 use anyhow::Result;
 use ignore::WalkBuilder;
-use log::{debug, warn};
+use log::{debug, info, warn};
 use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
 
@@ -83,10 +83,7 @@ impl ProjectScanner {
         file_info: &FileInfo,
         matrix: &mut ProjectMatrix,
     ) -> Result<crate::core::matrix::FileNode> {
-        debug!(
-            "🚀 Starting plugin analysis for: {}",
-            file_info.path.display()
-        );
+        info!("🚀 Starting analysis for: {}", file_info.path.display());
 
         use crate::plugins::communication::PluginCommunicator;
         use crate::plugins::interface::PluginInput;
@@ -106,7 +103,7 @@ impl ProjectScanner {
         // Resolve plugin path
         let plugin_path = match &plugin_config.source {
             crate::utils::config::PluginSource::Builtin { name } => {
-                PathBuf::from(format!("plugins/{name}_analyzer.py"))
+                PathBuf::from(format!("plugins/input/{name}_analyzer.py"))
             }
             _ => {
                 // TODO: Handle other plugin sources
@@ -168,8 +165,8 @@ impl ProjectScanner {
         debug!("🔄 Starting plugin communication...");
         match communicator.analyze(plugin_input).await {
             Ok(plugin_output) => {
-                debug!(
-                    "✅ Plugin analysis successful for: {} with {} elements",
+                info!(
+                    "✅ Analysis successful for: {} with {} elements",
                     file_info.path.display(),
                     plugin_output.elements.len()
                 );

--- a/src/plugins/manager.rs
+++ b/src/plugins/manager.rs
@@ -51,7 +51,9 @@ impl PluginManager {
             PluginSource::Local { path } => Ok(PathBuf::from(path)),
             PluginSource::Builtin { name: plugin_name } => {
                 // Built-in plugins are in the plugins/ directory
-                Ok(PathBuf::from(format!("plugins/{plugin_name}_analyzer.py")))
+                Ok(PathBuf::from(format!(
+                    "plugins/input/{plugin_name}_analyzer.py"
+                )))
             }
             PluginSource::GitHub { repo, version } => {
                 // TODO: Implement GitHub plugin downloading

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -17,8 +17,9 @@ import pytest
 PROJECT_ROOT = Path(__file__).parent.parent.parent
 PLUGINS_DIR = PROJECT_ROOT / "plugins"
 SHARED_DIR = PLUGINS_DIR / "shared"
+INPUT_DIR = PLUGINS_DIR / "input"
 
-sys.path.insert(0, str(PLUGINS_DIR))
+sys.path.insert(0, str(INPUT_DIR))
 sys.path.insert(0, str(SHARED_DIR))
 
 


### PR DESCRIPTION
This moves our existing plugins to an input directory and also adds an output directory. This begins our preparation for having both input plugins and output plugins.

Starts #11

## Todos

- [ ] Tests
- [ ] Documentation

## Deploy Notes (_optional_)

Notes regarding deployment the contained body of work.

## Steps to Test or Reproduce (_optional_)

Outline the steps to test or reproduce the PR here.

```sh
commands to test PR
```

## Impacted Areas in Application (_optional_)

List general components of the application that this PR will affect:

-
